### PR TITLE
Adds a simple script to sanity check generated blocklist data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is imported to our VPN servers frequently.
   - Ensure you have added any 'custom' extra lists or websites to block
   - Run the playbook: `ansible-playbook -i inventory/ playbook.yml`
   - View the output (once pushed) at `https://raw.githubusercontent.com/mullvad/dns-adblock/main/output/<group>.txt?raw=true`
+  - Run test script: `cd scripts && ./check_zonedata.sh`
 
 ## Pull requests / Issues / Updating block lists
 

--- a/scripts/check_zonedata.sh
+++ b/scripts/check_zonedata.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+if ! command -v named-checkzone &> /dev/null
+then
+  echo "named-checkzone is not installed"
+  echo "This is required to run this script and is installed as part of the bind-utils package"
+  exit
+fi
+
+for list in ../output/relay/*
+  do
+    echo "### $list"
+    temp_filename=$(basename "$list")
+    cat <<EOF > "$temp_filename"
+\$TTL    604800
+@       IN      SOA     ns.example.com. root.example.com. (
+                           1337         ; Serial
+                         604800         ; Refresh
+                          86400         ; Retry
+                        2419200         ; Expire
+                         604800 )       ; Negative Cache TTL
+;
+@	IN	NS	ns.example.com.
+EOF
+    while read -r hostname
+    do
+      echo "$hostname IN CNAME ." >> "$temp_filename"
+      done < "$list"
+      named-checkzone "$temp_filename" "$temp_filename"
+      rm "$temp_filename"
+      echo ""
+  done


### PR DESCRIPTION
A super simple script to check if the generated blocking lists contains any errors that would break later actions.

```
user@dev:~/code/dns-adblock$ cd scripts/ && ./check_zonedata.sh
### ../output/relay/relay_adblock.txt
zone relay_adblock.txt/IN: loaded serial 1337
OK

### ../output/relay/relay_privacy.txt
zone relay_privacy.txt/IN: loaded serial 1337
OK

### ../output/relay/relay_this_should_break
relay_this_should_break:10: unknown RR type 'localhost'
zone relay_this_should_break/IN: loading from master file relay_this_should_break failed: unknown class/type
zone relay_this_should_break/IN: not loaded due to errors.
```