### PR TITLE
dns-adblock/all.yml playbook.yml: added a trailing whitespace to 

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -5,7 +5,7 @@ dns_adblock_lists: "{{ dns_adblock_lists_defaults + dns_adblock_lists_extras }}"
 # Often blocklists contain these IPs. We want to remove them from our lists
 dns_replace_address:
   - '([0-9]{1,3}\.){3}[0-9]{1,3} '  # Beware of the necessary trailing whitespace!
-  - 'localhost'                     # It is there to not match records like 1.2.3.4.domain.tld
+  - 'localhost '                     # It is there to not match records like 1.2.3.4.domain.tld
   - '::1'
 
 dns_adblock_lists_defaults:

--- a/playbook.yml
+++ b/playbook.yml
@@ -89,3 +89,10 @@
       loop: "{{ group_names | product(dns_adblock_lists) | list }}"
       loop_control:
         label: "{{ item.1.name }}"
+
+    - name: Replace whitespace with new line
+      ansible.builtin.replace:
+        path: "output/{{ item.0 }}/{{ item.0 }}_{{ item.1.type }}.txt"
+        regexp: ' '
+        replace: '\n'
+      loop: "{{ group_names | product(dns_adblock_lists) | list }}"


### PR DESCRIPTION
localhost so we only remove the localhost in front of the domains and not remove localhost from domain names. Added a task to playbook so if there are multiple domains on the same line separated by white spaces it will move them to a new line instead.

This is what created the problems with the lists in the other PRs, so when adding new lists it should no longer complain.

