### PR TITLE
Replace SB adult list with separate lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ We currently use these advertising blocklists with our service:
 ### Adult content 
 
 We currently use this Adult content blocklist for our service:
-- StevenBlack-adult: https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/porn/hosts
+- brijrajparmar27-pornography: https://raw.githubusercontent.com/brijrajparmar27/host-sources/master/Porn/hosts
+- clefspeare13-pornhosts: https://raw.githubusercontent.com/StevenBlack/hosts/master/extensions/porn/clefspeare13/hosts
+- sinfonietta-snuff-hosts: https://raw.githubusercontent.com/Sinfonietta/hostfiles/master/snuff-hosts
+- sinfonietta-pornography-hosts: https://raw.githubusercontent.com/Sinfonietta/hostfiles/master/pornography-hosts
+- tiuxo-hostlist-pornography: https://raw.githubusercontent.com/tiuxo/hosts/master/porn
 
 ### Gambling
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -27,9 +27,6 @@ dns_adblock_lists_defaults:
   - name: yoyo
     url: https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=0&mimetype=plaintext
     type: adblock
-  - name: StevenBlack-adult
-    type: adult
-    url: https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/porn/hosts
   - name: blocklist-project
     url: https://raw.githubusercontent.com/blocklistproject/Lists/master/alt-version/gambling-nl.txt
     type: gambling
@@ -45,6 +42,21 @@ dns_adblock_lists_defaults:
   - name: AdguardDNS-mobile-ads
     type: adblock
     url: https://raw.githubusercontent.com/r-a-y/mobile-hosts/master/AdguardMobileAds.txt
+  - name: brijrajparmar27-pornography
+    type: adult
+    url: https://raw.githubusercontent.com/brijrajparmar27/host-sources/master/Porn/hosts
+  - name: clefspeare13-pornhosts
+    type: adult
+    url: https://raw.githubusercontent.com/StevenBlack/hosts/master/extensions/porn/clefspeare13/hosts
+  - name: sinfonietta-snuff-hosts
+    type: adult
+    url: https://raw.githubusercontent.com/Sinfonietta/hostfiles/master/snuff-hosts
+  - name: sinfonietta-pornography-hosts
+    type: adult
+    url: https://raw.githubusercontent.com/Sinfonietta/hostfiles/master/pornography-hosts
+  - name: tiuxo-hostlist-pornography
+    type: adult
+    url: https://raw.githubusercontent.com/tiuxo/hosts/master/porn
         
 # List of extra domains to block, in addition to what we have listed
 # in `dns_adblock_lists`


### PR DESCRIPTION
If I understand correctly these are the lists that are pulled into SBs adult list as part of the adult blocklist.
We pull in these lists separately to avoid pulling in the rest of SBs blocked hosts.
